### PR TITLE
resources/page: Add :sectionslug and :sectionslugs permalink tokens

### DIFF
--- a/docs/content/en/_common/permalink-tokens.md
+++ b/docs/content/en/_common/permalink-tokens.md
@@ -26,8 +26,14 @@ _comment: Do not remove front matter.
 `:section`
 : The content's section.
 
+`:sectionslug`
+: The content's section using slugified section name. The slugified section name is the `slug` as defined in front matter, else the `title` as defined in front matter, else the automatic title.
+
 `:sections`
 : The content's sections hierarchy. You can use a selection of the sections using _slice syntax_: `:sections[1:]` includes all but the first, `:sections[:last]` includes all but the last, `:sections[last]` includes only the last, `:sections[1:2]` includes section 2 and 3. Note that this slice access will not throw any out-of-bounds errors, so you don't have to be exact.
+
+`:sectionslugs`
+: The content's sections hierarchy using slugified section names. The slugified section name is the `slug` as defined in front matter, else the `title` as defined in front matter, else the automatic title. You can use a selection of the sections using _slice syntax_: `:sectionslugs[1:]` includes all but the first, `:sectionslugs[:last]` includes all but the last, `:sectionslugs[last]` includes only the last, `:sectionslugs[1:2]` includes section 2 and 3. Note that this slice access will not throw any out-of-bounds errors, so you don't have to be exact.
 
 `:title`
 : The `title` as defined in front matter, else the automatic title. Hugo generates titles automatically for section, taxonomy, and term pages that are not backed by a file.

--- a/resources/page/permalinks.go
+++ b/resources/page/permalinks.go
@@ -62,6 +62,14 @@ func (p PermalinkExpander) callback(attr string) (pageToPermaAttribute, bool) {
 		}, true
 	}
 
+	if strings.HasPrefix(attr, "sectionslugs[") {
+		fn := p.toSliceFunc(strings.TrimPrefix(attr, "sectionslugs"))
+		sectionSlugsFunc := p.withSectionPagesFunc(p.pageToPermalinkSlugElseTitle, func(s ...string) string {
+			return path.Join(fn(s)...)
+		})
+		return sectionSlugsFunc, true
+	}
+
 	// Make sure this comes after all the other checks.
 	if referenceTime.Format(attr) != attr {
 		return p.pageToPermalinkDate, true
@@ -87,7 +95,9 @@ func NewPermalinkExpander(urlize func(uri string) string, patterns map[string]ma
 		"weekdayname":           p.pageToPermalinkDate,
 		"yearday":               p.pageToPermalinkDate,
 		"section":               p.pageToPermalinkSection,
+		"sectionslug":           p.pageToPermalinkSectionSlug,
 		"sections":              p.pageToPermalinkSections,
+		"sectionslugs":          p.pageToPermalinkSectionSlugs,
 		"title":                 p.pageToPermalinkTitle,
 		"slug":                  p.pageToPermalinkSlugElseTitle,
 		"slugorfilename":        p.pageToPermalinkSlugElseFilename,
@@ -305,8 +315,27 @@ func (l PermalinkExpander) pageToPermalinkSection(p Page, _ string) (string, err
 	return p.Section(), nil
 }
 
+// pageToPermalinkSectionSlug returns the URL-safe form of the first section's slug or title
+func (l PermalinkExpander) pageToPermalinkSectionSlug(p Page, attr string) (string, error) {
+	if p.Section() == "" {
+		return "", nil
+	}
+
+	sectionPage, err := p.GetPage("/" + p.Section())
+	if err != nil {
+		return "", nil
+	}
+	return l.pageToPermalinkSlugElseTitle(sectionPage, attr)
+}
+
 func (l PermalinkExpander) pageToPermalinkSections(p Page, _ string) (string, error) {
 	return p.CurrentSection().SectionsPath(), nil
+}
+
+// pageToPermalinkSectionSlugs returns a path built from all ancestor sections using their slugs or titles
+func (l PermalinkExpander) pageToPermalinkSectionSlugs(p Page, attr string) (string, error) {
+	sectionSlugsFunc := l.withSectionPagesFunc(l.pageToPermalinkSlugElseTitle, path.Join)
+	return sectionSlugsFunc(p, attr)
 }
 
 // pageToPermalinkContentBaseName returns the URL-safe form of the content base name.
@@ -331,6 +360,36 @@ func (l PermalinkExpander) translationBaseName(p Page) string {
 		return ""
 	}
 	return p.File().TranslationBaseName()
+}
+
+// withSectionPagesFunc returns a function that builds permalink attributes from section pages.
+// It applies the transformation function f to each ancestor section (Page), then joins the results with the join function.
+//
+// Current use is create section-based hierarchical paths using section slugs.
+func (l PermalinkExpander) withSectionPagesFunc(f func(Page, string) (string, error), join func(...string) string) func(p Page, s string) (string, error) {
+	return func(p Page, s string) (string, error) {
+		var entries []string
+		sectionEntries := p.CurrentSection().SectionsEntries()
+
+		for i := range sectionEntries {
+			sectionPath := "/" + path.Join(sectionEntries[:i+1]...)
+			section, err := p.GetPage(sectionPath)
+			if err != nil {
+				return "", err
+			}
+			if section == nil {
+				return "", nil
+			}
+
+			entry, err := f(section, s)
+			if err != nil {
+				return "", err
+			}
+			entries = append(entries, entry)
+		}
+
+		return join(entries...), nil
+	}
 }
 
 var (

--- a/resources/page/permalinks_test.go
+++ b/resources/page/permalinks_test.go
@@ -62,6 +62,36 @@ var testdataPermalinks = []struct {
 		p.title = "mytitle"
 		p.file = source.NewContentFileInfoFrom("/", "_index.md")
 	}, "/test-page/"},
+	// slug, title.                                                         // Section slug
+	{"/:sectionslug/", true, func(p *testPage) {
+		p.doGetPage = func(string) Page {
+			return &testPage{slug: "my-slug"}
+		}
+	}, "/my-slug/"},
+	// slug, title.                                                         // Section slugs
+	{"/:sectionslugs/", true, func(p *testPage) {
+		p.doGetPage = func(ref string) Page {
+			return &testPage{
+				slug: ref[strings.LastIndex(ref, "/")+1:] + "-slug",
+			}
+		}
+	}, "/a-slug/b-slug/c-slug/"},
+	// slice: slug, title.
+	{"/:sectionslugs[0]/:sectionslugs[last]/", true, func(p *testPage) {
+		p.doGetPage = func(ref string) Page {
+			return &testPage{
+				slug: ref[strings.LastIndex(ref, "/")+1:] + "-slug",
+			}
+		}
+	}, "/a-slug/c-slug/"},
+	// slice: slug, title.
+	{"/:sectionslugs[last]/", true, func(p *testPage) {
+		p.doGetPage = func(ref string) Page {
+			return &testPage{
+				slug: ref[strings.LastIndex(ref, "/")+1:] + "-slug",
+			}
+		}
+	}, "/c-slug/"},
 	// Failures
 	{"/blog/:fred", false, nil, ""},
 	{"/:year//:title", false, nil, ""},

--- a/resources/page/permalinks_test.go
+++ b/resources/page/permalinks_test.go
@@ -64,33 +64,44 @@ var testdataPermalinks = []struct {
 	}, "/test-page/"},
 	// slug, title.                                                         // Section slug
 	{"/:sectionslug/", true, func(p *testPage) {
-		p.doGetPage = func(string) Page {
-			return &testPage{slug: "my-slug"}
-		}
+		p.currentSection = &testPage{slug: "my-slug"}
 	}, "/my-slug/"},
 	// slug, title.                                                         // Section slugs
 	{"/:sectionslugs/", true, func(p *testPage) {
-		p.doGetPage = func(ref string) Page {
-			return &testPage{
-				slug: ref[strings.LastIndex(ref, "/")+1:] + "-slug",
-			}
+		// Set up current section with ancestors
+		currentSection := &testPage{
+			slug: "c-slug",
+			kind: "section",
+			ancestors: Pages{
+				&testPage{slug: "b-slug", kind: "section"},
+				&testPage{slug: "a-slug", kind: "section"},
+			},
 		}
+		p.currentSection = currentSection
 	}, "/a-slug/b-slug/c-slug/"},
 	// slice: slug, title.
 	{"/:sectionslugs[0]/:sectionslugs[last]/", true, func(p *testPage) {
-		p.doGetPage = func(ref string) Page {
-			return &testPage{
-				slug: ref[strings.LastIndex(ref, "/")+1:] + "-slug",
-			}
+		currentSection := &testPage{
+			slug: "c-slug",
+			kind: "section",
+			ancestors: Pages{
+				&testPage{slug: "b-slug", kind: "section"},
+				&testPage{slug: "a-slug", kind: "section"},
+			},
 		}
+		p.currentSection = currentSection
 	}, "/a-slug/c-slug/"},
 	// slice: slug, title.
 	{"/:sectionslugs[last]/", true, func(p *testPage) {
-		p.doGetPage = func(ref string) Page {
-			return &testPage{
-				slug: ref[strings.LastIndex(ref, "/")+1:] + "-slug",
-			}
+		currentSection := &testPage{
+			slug: "c-slug",
+			kind: "section",
+			ancestors: Pages{
+				&testPage{slug: "b-slug", kind: "section"},
+				&testPage{slug: "a-slug", kind: "section"},
+			},
 		}
+		p.currentSection = currentSection
 	}, "/c-slug/"},
 	// Failures
 	{"/blog/:fred", false, nil, ""},

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -111,6 +111,9 @@ type testPage struct {
 
 	currentSection *testPage
 	sectionEntries []string
+
+	// Functions
+	doGetPage func(ref string) Page
 }
 
 func (p *testPage) Aliases() []string {
@@ -210,6 +213,9 @@ func (p *testPage) FuzzyWordCount(context.Context) int {
 }
 
 func (p *testPage) GetPage(ref string) (Page, error) {
+	if p.doGetPage != nil {
+		return p.doGetPage(ref), nil
+	}
 	panic("testpage: not implemented")
 }
 

--- a/resources/page/testhelpers_test.go
+++ b/resources/page/testhelpers_test.go
@@ -111,9 +111,7 @@ type testPage struct {
 
 	currentSection *testPage
 	sectionEntries []string
-
-	// Functions
-	doGetPage func(ref string) Page
+	ancestors      Pages
 }
 
 func (p *testPage) Aliases() []string {
@@ -205,7 +203,12 @@ func (p *testPage) Filename() string {
 }
 
 func (p *testPage) FirstSection() Page {
-	panic("testpage: not implemented")
+	// Return the current section for regular pages
+	// For section pages, this would be the section itself
+	if p.currentSection != nil {
+		return p.currentSection
+	}
+	return p // If no current section, assume this page is the section
 }
 
 func (p *testPage) FuzzyWordCount(context.Context) int {
@@ -213,9 +216,6 @@ func (p *testPage) FuzzyWordCount(context.Context) int {
 }
 
 func (p *testPage) GetPage(ref string) (Page, error) {
-	if p.doGetPage != nil {
-		return p.doGetPage(ref), nil
-	}
 	panic("testpage: not implemented")
 }
 
@@ -268,7 +268,7 @@ func (p *testPage) IsDraft() bool {
 }
 
 func (p *testPage) IsHome() bool {
-	panic("testpage: not implemented")
+	return p.kind == "home"
 }
 
 func (p *testPage) IsMenuCurrent(menuID string, inme *navigation.MenuEntry) bool {
@@ -284,7 +284,7 @@ func (p *testPage) IsPage() bool {
 }
 
 func (p *testPage) IsSection() bool {
-	panic("testpage: not implemented")
+	return p.kind == "section"
 }
 
 func (p *testPage) IsTranslated() bool {
@@ -292,7 +292,7 @@ func (p *testPage) IsTranslated() bool {
 }
 
 func (p *testPage) Ancestors() Pages {
-	panic("testpage: not implemented")
+	return p.ancestors
 }
 
 func (p *testPage) Keywords() []string {


### PR DESCRIPTION
Add slugified section permalink tokens with fallback behavior and slice syntax support.

1. `:sectionslug`: the content's section using the section's `slug` frontmatter parameter, else falling back to its `title` parameters.
1. `:sectionslugs`: the content's sections hierarchy, using each section's respective `slug` frontmatter parameter, else falling back to its `title` parameter.

Includes integration tests and documentation updates.

Closes [#13788](https://github.com/gohugoio/hugo/issues/13788)